### PR TITLE
bug: add validation to prevent private_only and ip_connect together

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,10 @@ The Azure Bastion Host configuration.
     error_message = "IP connect is only available for Standard or Premium SKU."
   }
   validation {
+    condition     = var.bastion.private_only_enabled && var.bastion.ip_connect_enabled ? false : true
+    error_message = "IP connect cannot be enabled when private-only mode is enabled."
+  }
+  validation {
     condition     = var.bastion.file_copy_enabled == true ? contains(["Standard", "Premium"], var.bastion.sku) : true
     error_message = "File copy is only available for Standard or Premium SKU."
   }


### PR DESCRIPTION
Adding a validation rule that prevents enabling both private_only_enabled and ip_connect_enabled simultaneously, as this combination results in a failed deployment.